### PR TITLE
feat: Deprecate and replace clearDeviceData

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/MarigoldSwift.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/MarigoldSwift.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1410"
-   version = "1.3">
+   LastUpgradeVersion = "1500"
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -40,7 +40,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/sailthru/sailthru-mobile-ios-sdk",
         "state": {
           "branch": null,
-          "revision": "4d6c5dfaff08220ba544007d34768ed68220ef4c",
-          "version": "15.0.0"
+          "revision": "2e71269a5ce5c75009f2002873af5fa31bd10ce4",
+          "version": "15.1.0"
         }
       }
     ]

--- a/Sources/MarigoldSwift/EngageBySailthru+Concurrency.swift
+++ b/Sources/MarigoldSwift/EngageBySailthru+Concurrency.swift
@@ -87,6 +87,17 @@ extension EngageBySailthru {
         })
     }
     
+    // MARK: Events
+    
+    /**
+     * Clear the custom events from the device data.
+     */
+    public func clearEvents() async throws {
+        try await withCheckedThrowingContinuation({ continuation in
+            clearEvents(response: ClosureBuilder.voidErrorClosure(continuation))
+        })
+    }
+    
     /**
      *  Registers that the given pageview with Sailthru SPM.
      *

--- a/Sources/MarigoldSwift/MARMessageStream+Concurrency.swift
+++ b/Sources/MarigoldSwift/MARMessageStream+Concurrency.swift
@@ -92,4 +92,13 @@ extension MARMessageStream {
             remove(message, withResponse: ClosureBuilder.voidErrorClosure(continuation))
         })
     }
+    
+    /**
+     * Clear the Message Stream for the device.
+     */
+    public func clearMessages() async throws {
+        try await withCheckedThrowingContinuation({ continuation in
+            clearMessages(response: ClosureBuilder.voidErrorClosure(continuation))
+        })
+    }
 }

--- a/Sources/MarigoldSwift/Marigold+Concurrency.swift
+++ b/Sources/MarigoldSwift/Marigold+Concurrency.swift
@@ -30,6 +30,7 @@ extension Marigold {
      *  - Parameter types: A bitwise OR collection of STMDeviceDataType dictating which sets of data to clear.
      *  - Throws: Error when call fails.
      **/
+    @available(*, deprecated, message: "Use EngageBySailthru.clearEvents or MARMessageStream.clearMessages instead.")
     public func clearDeviceData(for types: MARDeviceDataType) async throws {
         try await withCheckedThrowingContinuation({ continuation in
             clear(types, withResponse: ClosureBuilder.voidErrorClosure(continuation))

--- a/Tests/MarigoldSwiftTests/DummyMARMessageStream.swift
+++ b/Tests/MarigoldSwiftTests/DummyMARMessageStream.swift
@@ -45,4 +45,8 @@ class DummyMARMessageStream : MARMessageStream {
         handler?(responseError)
     }
     
+    public override func clearMessages(response handler: ((Error?) -> Void)? = nil) {
+        calledFunctions.append(#function)
+        handler?(responseError)
+    }
 }

--- a/Tests/MarigoldSwiftTests/MARMessageStream+ConcurrencySpec.swift
+++ b/Tests/MarigoldSwiftTests/MARMessageStream+ConcurrencySpec.swift
@@ -144,6 +144,23 @@ final class MARMessageStreamConcurrencySpec: XCTestCase {
         }
     }
     
+    func test_clearMessages_callsCorrectMethod() async throws {
+        try await subject.clearMessages()
+        
+        checkMethodCalled(with: "clearMessages")
+    }
+    
+    func test_clearMessages_throwsOnError() async throws {
+        subject.responseError = TestErrors.testError
+        do {
+            try await subject.clearMessages()
+            XCTFail("Should throw provided error")
+        } catch TestErrors.testError {
+        } catch {
+            XCTFail("Incorrect error thrown: \(error)")
+        }
+    }
+    
     
     // MARK: Helpers
     


### PR DESCRIPTION
This PR:
* Deprecates the `Marigold clearDeviceData` method and replaces it with `EngageBySailthru clearEvents` and `MARMessageStream clearMessages` methods, in line with the base iOS SDK.